### PR TITLE
hide overflowing descriptions to prevent chaos on small screens

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,14 +1,11 @@
 import React, { PropTypes } from 'react';
 
-const stylesNormal = {overflow: 'visible'};
-const stylesLarge = {overflow: 'visible', height: 'auto'};
-
 function Item ({title, description, children, disabled, large}) {
   const isDisabled = disabled ? 'disabled' : '';
   return (
     <li
       className={`mdl-list__item mdl-list__item--two-line ${isDisabled}`}
-      style={large ? stylesLarge : stylesNormal}
+      style={{overflow: 'hidden', 'margin-bottom': '20px', height: 'auto'}}
       >
       <span className='mdl-list__item-primary-content'>
         <span>{title}</span>


### PR DESCRIPTION
Beta tester reported poor overflow handling when screen is adjusted to not be very wide. I think it's better for us to just truncate if this happens.
![unnamed](https://cloud.githubusercontent.com/assets/288011/24453905/b19c742a-1457-11e7-8aab-24453a6cee4a.png)
