### PR TITLE
add version compatibility note

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -4,7 +4,7 @@ function TopBar () {
   return (
     <div className='mdl-layout__header'>
       <div className='mdl-layout__header-row'>
-        <span className='mdl-layout-title'>Bitcoin Core Config Generator</span>
+        <span className='mdl-layout-title'>Bitcoin Core Config Generator (compatible with Bitcoin Core 0.14+)</span>
         <div className='mdl-layout-spacer' />
       </div>
     </div>


### PR DESCRIPTION
Beta tester suggested that the generator note which version(s) of Core it's compatible with. This will add a note on the top bar.