### PR TITLE
allow long descriptions to overflow gracefully

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -9,7 +9,7 @@ function Item ({title, description, children, disabled, large}) {
       >
       <span className='mdl-list__item-primary-content'>
         <span>{title}</span>
-        <span className='mdl-list__item-sub-title'>
+        <span className='mdl-list__item-sub-title' style={{overflow: 'auto', height: '100%'}}>
           {description}
         </span>
       </span>


### PR DESCRIPTION
Fixes #13 - now the browser will add scroll bars if the description text is too large to fit inside its container.