### PR TITLE
fix bandwidth presets

### DIFF
--- a/src/components/Presets/bandwidth.json
+++ b/src/components/Presets/bandwidth.json
@@ -1,6 +1,8 @@
 {
   "core": {
-    "blocksonly": true,
+    "blocksonly": 1
+   },
+   "network": {
     "maxconnections": 20,
     "maxuploadtarget": 500
   }


### PR DESCRIPTION
The network options weren't defined as being in the network section, thus they weren't being rendered.