### PR TITLE
set "server" default to false

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -621,7 +621,7 @@
     "server": {
       "name": "Enable RPC Server",
       "description": "Accept command line and JSON-RPC commands.",
-      "default": 1
+      "default": 0
     },
     "rest": {
       "name": "Enable REST API",


### PR DESCRIPTION
The default for enabling the RPC server in Core is false, not true

Fixes #20 