### PR TITLE
Updated the dbcache default from 300 to 450

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -58,7 +58,7 @@
     "dbcache": {
       "name": "DB Cache Size",
       "description": "Set database cache size in megabytes; machines sync faster with a larger cache. Recommend setting as high as possible based upon machine's available RAM.",
-      "default": 300,
+      "default": 450,
       "min": 4
     },
     "feefilter": {


### PR DESCRIPTION
Updated the dbcache default from 300 to 450MiB per the [release notes for version 0.14.1](https://github.com/bitcoin/bitcoin/blob/f8feaa4636260b599294c7285bcf1c8b7737f74e/doc/release-notes/release-notes-0.14.1.md#utxo-memory-accounting)