### PR TITLE
Removing blockmaxsize option from mining as it was removed in 0.16.1 by PR #12756

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -92,7 +92,6 @@ class Editor extends Component {
         </Section>
         <Section title={data.mining.section} description={data.mining.description}>
           { this.number('mining', 'blockmaxweight') }
-          { this.number('mining', 'blockmaxsize') }
           { this.decimal('mining', 'blockmintxfee') }
           { this.text('mining', 'blockversion') }
         </Section>

--- a/src/components/Presets/mining.json
+++ b/src/components/Presets/mining.json
@@ -9,8 +9,7 @@
     "maxsigcachesize": 100
   },
   "mining": {
-    "blockmaxweight": 4000000,
-    "blockmaxsize": 1000000
+    "blockmaxweight": 4000000
   },
   "network": {
     "peerbloomfilters": 0

--- a/src/data.json
+++ b/src/data.json
@@ -688,11 +688,6 @@
       "description": "Set maximum BIP141 block weight.",
       "default": 3000000
     },
-    "blockmaxsize": {
-      "name": "Max Block Size",
-      "description": "Set maximum block size in bytes.",
-      "default": 750000
-    },
     "blockmintxfee": {
       "name": "Block Min Transaction Fee",
       "description": "Set lowest fee rate (in BTC/kB) for transactions to be included in block creation.",


### PR DESCRIPTION
Sources:
https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.16.1.md
https://github.com/bitcoin/bitcoin/pull/12756

Fixes #27.