### PR TITLE
rpcbind: adapt to the default interfaces of bitcoin-core

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -769,7 +769,7 @@
     },
     "rpcbind": {
       "name": "Bind RPC Address",
-      "description": "Bind to given address to listen for JSON-RPC connections. This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times. (default: 127.0.0.1 and ::1 i.e., localhost, or if -rpcallowip has been specified, 0.0.0.0 and :: i.e., all addresses)",
+      "description": "Bind to given address to listen for JSON-RPC connections. This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times. (default: 127.0.0.1 and ::1 i.e., localhost)",
       "default": ""
     },
     "rpccookiefile": {


### PR DESCRIPTION
Binding to 0.0.0.0 is not a default since v.0.18.0.
So if '-rpcallowip' is specified without setting '-rpcbind', a warning is given by bitcoind and RPCs can only be received by the local loopback interface.

The commit where this change was introduced: https://github.com/bitcoin/bitcoin/commit/3615003952ffbc814bdb53d9d0e45790f152bd2f