### PR TITLE
Disable peerbloomfilters as default

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -652,7 +652,7 @@
     "peerbloomfilters": {
       "name": "Permit Peer Bloom Filters",
       "description": "Support filtering of blocks and transactions with bloom filters.",
-      "default": 1
+      "default": 0
     },
     "peertimeout": {
       "name": "Peer Timeout",


### PR DESCRIPTION
The default value for the peerbloomfilters configuration was changed to false in version 0.19.0.1

https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.19.0.1.md