### PR TITLE
[FIX] v2transport enabled by default since Bitcoin Core v27

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -727,7 +727,7 @@
     "v2transport": {
       "name": "Support v2 Transport",
       "description": "Experimental support for the v2 transport protocol defined in BIP324.",
-      "default": 0
+      "default": 1
     },
     "peerblockfilters": {
       "name": "Permit Peer Block Filters",


### PR DESCRIPTION
Since Bitcoin Core v27 v2transport is enabled by default. Opt-out with v2transport=0

Changed according to this on the initial template

Refs:
https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.0.md#p2p-and-network-changes
https://github.com/bitcoin/bitcoin/pull/29347

![imagen](https://github.com/jlopp/bitcoin-core-config-generator/assets/89636253/f3608724-4d57-4940-b2f4-004d638b7dea)