### PR TITLE
Make the preview card stick when scrolling

### DIFF
--- a/src/components/Preview.css
+++ b/src/components/Preview.css
@@ -3,6 +3,8 @@
 }
 .preview-card.mdl-card {
   width: 100%;
+  position: sticky;
+  top: 0.5rem;
 }
 .preview-editor {
   width: 100%;


### PR DESCRIPTION
It's a small change, but it's something that I always used (injected into the page with Stylebot)

https://github.com/user-attachments/assets/41382bb7-f5ff-4d1d-a058-db380d1bc38e

